### PR TITLE
Regression to gcc

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:latest
 RUN apt update && apt upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt install -y \
         sudo git wget lsb-release software-properties-common gnupg \
-        build-essential binutils python3 python3-pip cmake ninja-build \
+        build-essential gdb binutils python3 python3-pip cmake ninja-build \
         pkg-config mold libzstd-dev libcurl4-openssl-dev libedit-dev \
         zlib1g-dev libffi-dev libtinfo-dev libxml2-dev locales \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,8 +21,8 @@
       "inherits": "x64-base",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-17",
-        "CMAKE_CXX_COMPILER": "clang++-17"
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++"
       },
       "condition": {
         "type": "equals",


### PR DESCRIPTION
LLVM debug not supported in vscode without previous config
